### PR TITLE
SPARQL::Grammar.valid? now returns true when the query is valid

### DIFF
--- a/lib/sparql/grammar/parser11.rb
+++ b/lib/sparql/grammar/parser11.rb
@@ -1090,6 +1090,7 @@ module SPARQL::Grammar
     # @return [Boolean]
     def valid?
       parse
+      true
     rescue Error
       false
     end


### PR DESCRIPTION
SPARQL::Grammar::Parser#valid? and SPARQL::Grammar.valid? now returns true when the query is valid (instead of the result of the parsing).

I didn't add any tests since this method was not tested anyway.

Signed-off-by: Aymeric Brisse aymeric.brisse@perfect-memory.com
