### PR TITLE
fixing missing `block` argument in sequence operator

### DIFF
--- a/lib/sparql/algebra/operator/sequence.rb
+++ b/lib/sparql/algebra/operator/sequence.rb
@@ -28,7 +28,7 @@ module SPARQL; module Algebra
       # @yieldparam  [RDF::Query::Solution] solution
       # @yieldreturn [void] ignored
       # @see    https://www.w3.org/TR/sparql11-query/#sparqlAlgebra
-      def execute(queryable, **options)
+      def execute(queryable, **options, &block)
         debug(options) {"Sequence #{operands.to_sse}"}
 
         last = queryable.query(operands.shift, **options.merge(depth: options[:depth].to_i + 1))


### PR DESCRIPTION
Found this crash scenario. Apparently I had fixed this months ago and not submitted?